### PR TITLE
Add alternative tab trigger for print and comment ERB tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ These snippets can now be installed via [Sublime Package Control](http://wbond.n
   </tr>
   <tr>
     <td>print ERB tags</td>
-    <td>__pe__</td>
+    <td>__pe__ or __erp__</td>
     <td>`<%=  %>`</td>
   </tr>
   <tr>
     <td>print ERB comment</td>
-    <td>__pc__</td>
+    <td>__pc__ or __erc__</td>
     <td>`<%#  %>`</td>
   </tr>
   <tr>

--- a/comment_erb_erc.sublime-snippet
+++ b/comment_erb_erc.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[<%# $0 %>]]></content>
+  <tabTrigger>erc</tabTrigger>
+  <scope>text.html.ruby</scope>
+  <description>output ERB tags</description>
+</snippet>

--- a/print_erb_erp.sublime-snippet
+++ b/print_erb_erp.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[<%= $0 %>]]></content>
+	<tabTrigger>erp</tabTrigger>
+	<scope>text.html.ruby</scope>
+	<description>output ERB tags</description>
+</snippet>


### PR DESCRIPTION
Added 2 new tab triggers:
- `erp` for `<%=  %>`
- `erc` for `<%#  %>`
