### PR TITLE
Add hint for resolving conflicted tab triggers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ These snippets can now be installed via [Sublime Package Control](http://wbond.n
   </tr>
 <table>
 
+##Resolve conflicted tab trigger
+
+Some tab trigger can be conflicted to others, such as built-in Rails package or [Rails Developer Snippets](https://github.com/j10io/railsdev-sublime-snippets). You may want to disable unwanted snippets.
+
+### For Sublime Text 2
+
+Delete unwanted snippet file from `~/Library/Application\ Support/Sublime\ Text\ 2/Packages/<PackageName>/`
+
+### For Sublime Text 3
+
+1. Install [PackageResourceViewer](https://github.com/skuroda/PackageResourceViewer) Package
+2. Open unwanted sinppets with `PackageResourceViewer: Open Resource` command and comment it out
+
 ##Questions, Comments, Concerns?
 
 Feel free to submit a pull request with any snippets you would like to add to the project. If you have any problems or suggestions you can contact me [on twitter](https://twitter.com/mattdrobertson).


### PR DESCRIPTION
This can help avoiding this situation:

![](http://i.imgur.com/vWXIMA8.png)

Sorry for my bad English. Please feel free to rewrite this section it if you want. Thanks.
