### PR TITLE
form_for trigger to ff

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ These snippets can now be installed via [Sublime Package Control](http://wbond.n
   </tr>
   <tr>
     <td>`form_for` helper</td>
-    <td>__form__</td>
+    <td>__ff__</td>
     <td>`<%= form_for(@ ) do |f| %> ... <% end %>`</td>
   </tr>
   <tr>

--- a/form_for_erb.sublime-snippet
+++ b/form_for_erb.sublime-snippet
@@ -3,7 +3,7 @@
 		$3
 <% end %>
   ]]></content>
-  <tabTrigger>form</tabTrigger>
+  <tabTrigger>ff</tabTrigger>
   <scope>text.html.ruby</scope>
   <description>output form_for ERB</description>
 </snippet>


### PR DESCRIPTION
Changed trigger for form_for, from 'form' to 'ff' because the default sublime 'form' trigger creates a form html tag.