### PR TITLE
Update to use form_with in modern rails apps.

### DIFF
--- a/form_for_erb.sublime-snippet
+++ b/form_for_erb.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
-  <content><![CDATA[<%= form_for(${1:@things}) do |${2:f}| %>
+  <content><![CDATA[<%= form_with(${1:model: thing, local: true}) do |${2:f}| %>
 		$3
 <% end %>
   ]]></content>
-  <tabTrigger>ff</tabTrigger>
+  <tabTrigger>fw</tabTrigger>
   <scope>text.html.ruby</scope>
-  <description>output form_for ERB</description>
+  <description>output form_with ERB</description>
 </snippet>


### PR DESCRIPTION
Generate form_with from fw 
```
<%= form_with(model: thing, local: true) do |f| %>
		
<% end %>
```