### PR TITLE
Adapt snippet scope to Sublime Text 4 build 4134

### DIFF
--- a/cl_image_tag.sublime-snippet
+++ b/cl_image_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= cl_image_tag '${1:photo_path}' {${2:options?}} %>]]></content>
   <tabTrigger>cli</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert a rails view cloudinary cl_image_tag helper</description>
 </snippet>

--- a/comment_erb.sublime-snippet
+++ b/comment_erb.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%# $0 %>]]></content>
   <tabTrigger>pc</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>comment ERB tags</description>
 </snippet>

--- a/each_erb.sublime-snippet
+++ b/each_erb.sublime-snippet
@@ -5,6 +5,6 @@
 <% end %>
 ]]></content>
 	<tabTrigger>each</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>ERB each block</description>
 </snippet>

--- a/else_erb.sublime-snippet
+++ b/else_erb.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[<% else %>]]></content>
     <tabTrigger>else</tabTrigger>
-    <scope>text.html.ruby</scope>
+    <scope>text.html.rails</scope>
     <description>ERB else tag</description>
 </snippet>

--- a/elsif_erb.sublime-snippet
+++ b/elsif_erb.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[<% elsif ${1:true} %>]]></content>
     <tabTrigger>elsif</tabTrigger>
-    <scope>text.html.ruby</scope>
+    <scope>text.html.rails</scope>
     <description>ERB elsif tag</description>
 </snippet>

--- a/end_erb.sublime-snippet
+++ b/end_erb.sublime-snippet
@@ -3,6 +3,6 @@
 <% end %>
 ]]></content>
 	<tabTrigger>end</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>ERB end tag</description>
 </snippet>

--- a/erb_translation.sublime-snippet
+++ b/erb_translation.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= t('$0') %>]]></content>
   <tabTrigger>t</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>output ERB translation tags</description>
 </snippet>

--- a/f_input.sublime-snippet
+++ b/f_input.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= f.input $1 %>]]></content>
   <tabTrigger>fi</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert input for simple_form_for</description>
 </snippet>

--- a/f_submit_button.sublime-snippet
+++ b/f_submit_button.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= f.button :submit $1 %>]]></content>
   <tabTrigger>fs</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert submit button for simple_form_for</description>
 </snippet>

--- a/form_for_erb.sublime-snippet
+++ b/form_for_erb.sublime-snippet
@@ -4,6 +4,6 @@
 <% end %>
   ]]></content>
   <tabTrigger>ff</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>output form_for ERB</description>
 </snippet>

--- a/if_else_erb.sublime-snippet
+++ b/if_else_erb.sublime-snippet
@@ -7,6 +7,6 @@
 <% end %>
 ]]></content>
 	<tabTrigger>ife</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>ERB if / else / end</description>
 </snippet>

--- a/if_erb.sublime-snippet
+++ b/if_erb.sublime-snippet
@@ -5,6 +5,6 @@
 <% end %>
 ]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>ERB if / end</description>
 </snippet>

--- a/image_tag.sublime-snippet
+++ b/image_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= image_tag "${1:source}", alt: "${2:alttext}" %>]]></content>
   <tabTrigger>it</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert a rails view image_tag helper</description>
 </snippet>

--- a/label_tag.sublime-snippet
+++ b/label_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= label_tag (:${1:thing}, "${2:Your label text}") %>]]></content>
 	<tabTrigger>lblt</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>insert a rails view label_tag helper</description>
 </snippet>

--- a/link_to.sublime-snippet
+++ b/link_to.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= link_to $1, $2 %>]]></content>
 	<tabTrigger>lt</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>insert a rails view link_to helper</description>
 </snippet>

--- a/password_tag.sublime-snippet
+++ b/password_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= password_field_tag(:${1:thing} %>]]></content>
 	<tabTrigger>pft</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>insert a rails view password_field_tag helper</description>
 </snippet>

--- a/print_erb.sublime-snippet
+++ b/print_erb.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= $0 %>]]></content>
 	<tabTrigger>pe</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>output ERB tags</description>
 </snippet>

--- a/simple_form_for.sublime-snippet
+++ b/simple_form_for.sublime-snippet
@@ -4,6 +4,6 @@
 <% end %>
   ]]></content>
   <tabTrigger>sf</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert a simple_form_for frame</description>
 </snippet>

--- a/submit_tag.sublime-snippet
+++ b/submit_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= submit_tag "${1:My Button Text}", class: "${2:class}" %>]]></content>
 	<tabTrigger>st</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>insert a rails view submit_tag helper</description>
 </snippet>

--- a/text_field_tag.sublime-snippet
+++ b/text_field_tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<%= text_field_tag "${1:name}", "${2:value}", placeholder: "${3:placeholder}", class: "${4:class}" %>]]></content>
 	<tabTrigger>tft</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>insert a rails view text_field_tag helper</description>
 </snippet>

--- a/time_ago_in_words.sublime-snippet
+++ b/time_ago_in_words.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[<%= time_ago_in_words($1) %>]]></content>
   <tabTrigger>tw</tabTrigger>
-  <scope>text.html.ruby</scope>
+  <scope>text.html.rails</scope>
   <description>insert a rails view time_ago_in_words helper</description>
 </snippet>

--- a/unless_erb.sublime-snippet
+++ b/unless_erb.sublime-snippet
@@ -5,6 +5,6 @@
 <% end %>
 ]]></content>
 	<tabTrigger>unless</tabTrigger>
-	<scope>text.html.ruby</scope>
+	<scope>text.html.rails</scope>
 	<description>ERB unless / end</description>
 </snippet>


### PR DESCRIPTION
Hi :wave: 

From what I've understood, [Sublime Text 4 build 4134 introduced new syntax scope rules](https://www.sublimetext.com/dev) which breaks most of the current snippets relying on `text.html.ruby` scope.

https://github.com/matthewrobertson/ERB-Sublime-Snippets/pull/28 fixed it but for the `er` snippet only. 

This PR extends the fix for all snippets. 

Tested on my machine with Sublime Text build 4134 :heavy_check_mark: 